### PR TITLE
fix(snapshot): retry rsync/curl and randomize timer

### DIFF
--- a/imageroot/bin/take-snapshot
+++ b/imageroot/bin/take-snapshot
@@ -11,13 +11,35 @@ shopt -s nullglob
 # shellcheck disable=SC1091
 source /etc/nethserver/core.env
 snapshot_retention=${PORTHOS_RETENTION:-45}
-rsync_max_attempts=${PORTHOS_RSYNC_MAX_ATTEMPTS:-3}
-rsync_retry_delay=${PORTHOS_RSYNC_RETRY_DELAY:-60}
+retry_max_attempts=${PORTHOS_RETRY_MAX_ATTEMPTS:-3}
+retry_delay=${PORTHOS_RETRY_DELAY:-60}
 snapshot_dir=tmp.$(date +d%Y%m%dt%H%I%S%2N)
 mirror_base_url=${PORTHOS_SOURCE:?}
 repo_path_list=(/rocky/9/BaseOS/x86_64/os/ /rocky/9/AppStream/x86_64/os/)
 rsync_opts=(-aiSH --no-motd --no-super --no-perms --chmod=ugo=rwX --no-g --no-o --delete-after)
 distfeed_url=https://github.com/NethServer/ns8-repomd/archive/refs/heads/repomd.tar.gz
+
+# Run "$@", retrying on failure up to retry_max_attempts times with a
+# retry_delay pause in between. Useful to ride out transient network or
+# mirror-side errors without failing the whole snapshot run.
+retry() {
+    local attempt=1 rc=0
+    while true; do
+        rc=0
+        time "$@" || rc=$?
+        if [[ ${rc} -eq 0 ]]; then
+            return 0
+        fi
+        if [[ ${attempt} -ge ${retry_max_attempts} ]]; then
+            printf "Command failed (exit %d) after %d attempt(s), giving up: %s\n" "${rc}" "${attempt}" "$*" >&2
+            return "${rc}"
+        fi
+        printf "Command failed (exit %d), retrying in %ds (attempt %d/%d): %s\n" \
+            "${rc}" "${retry_delay}" "$((attempt + 1))" "${retry_max_attempts}" "$*" >&2
+        sleep "${retry_delay}"
+        ((attempt++))
+    done
+}
 
 cd $(podman volume inspect webroot | jq -r '.[]
     | if .Options.type == "bind" and (.Options.device? != null)
@@ -35,34 +57,19 @@ trap 'rm -rf "${snapshot_dir}"' EXIT
 
 printf "Fetching distfeed from %s\n" "${distfeed_url}"
 mkdir -vp "${snapshot_dir}/distfeed"
-curl --fail -L -O --output-dir "${snapshot_dir}" "${distfeed_url}"
+retry curl --fail -L -O --output-dir "${snapshot_dir}" "${distfeed_url}"
 tar -z -x --strip-components=1 -f "${snapshot_dir}/repomd.tar.gz" -C "${snapshot_dir}/distfeed"
 rm -f "${snapshot_dir}/repomd.tar.gz"
 
 for repo_path in "${repo_path_list[@]}"; do
     printf "Synchronizing %s\n" "${mirror_base_url}${repo_path}"
     mkdir -vp "${snapshot_dir}${repo_path}"
-    attempt=1
-    while true; do
-        rsync_rc=0
-        time podman run \
-            --network=host --rm --replace --name=take-snapshot \
-            --volume=webroot:/srv/porthos/webroot \
-            --workdir=/srv/porthos/webroot \
-            "${RSYNC_IMAGE:?}" \
-            rsync "${rsync_opts[@]}" "${mirror_base_url}${repo_path}" "${snapshot_dir}${repo_path}" || rsync_rc=$?
-        if [[ ${rsync_rc} -eq 0 ]]; then
-            break
-        fi
-        if [[ ${attempt} -ge ${rsync_max_attempts} ]]; then
-            printf "rsync failed (exit %d) after %d attempt(s), giving up\n" "${rsync_rc}" "${attempt}" >&2
-            exit "${rsync_rc}"
-        fi
-        printf "rsync failed (exit %d), retrying in %ds (attempt %d/%d)\n" \
-            "${rsync_rc}" "${rsync_retry_delay}" "$((attempt + 1))" "${rsync_max_attempts}" >&2
-        sleep "${rsync_retry_delay}"
-        ((attempt++))
-    done
+    retry podman run \
+        --network=host --rm --replace --name=take-snapshot \
+        --volume=webroot:/srv/porthos/webroot \
+        --workdir=/srv/porthos/webroot \
+        "${RSYNC_IMAGE:?}" \
+        rsync "${rsync_opts[@]}" "${mirror_base_url}${repo_path}" "${snapshot_dir}${repo_path}"
     printf "\n"
 done
 

--- a/imageroot/bin/take-snapshot
+++ b/imageroot/bin/take-snapshot
@@ -11,6 +11,8 @@ shopt -s nullglob
 # shellcheck disable=SC1091
 source /etc/nethserver/core.env
 snapshot_retention=${PORTHOS_RETENTION:-45}
+rsync_max_attempts=${PORTHOS_RSYNC_MAX_ATTEMPTS:-3}
+rsync_retry_delay=${PORTHOS_RSYNC_RETRY_DELAY:-60}
 snapshot_dir=tmp.$(date +d%Y%m%dt%H%I%S%2N)
 mirror_base_url=${PORTHOS_SOURCE:?}
 repo_path_list=(/rocky/9/BaseOS/x86_64/os/ /rocky/9/AppStream/x86_64/os/)
@@ -40,12 +42,27 @@ rm -f "${snapshot_dir}/repomd.tar.gz"
 for repo_path in "${repo_path_list[@]}"; do
     printf "Synchronizing %s\n" "${mirror_base_url}${repo_path}"
     mkdir -vp "${snapshot_dir}${repo_path}"
-    time podman run \
-        --network=host --rm --replace --name=take-snapshot \
-        --volume=webroot:/srv/porthos/webroot \
-        --workdir=/srv/porthos/webroot \
-        "${RSYNC_IMAGE:?}" \
-        rsync "${rsync_opts[@]}" "${mirror_base_url}${repo_path}" "${snapshot_dir}${repo_path}"
+    attempt=1
+    while true; do
+        rsync_rc=0
+        time podman run \
+            --network=host --rm --replace --name=take-snapshot \
+            --volume=webroot:/srv/porthos/webroot \
+            --workdir=/srv/porthos/webroot \
+            "${RSYNC_IMAGE:?}" \
+            rsync "${rsync_opts[@]}" "${mirror_base_url}${repo_path}" "${snapshot_dir}${repo_path}" || rsync_rc=$?
+        if [[ ${rsync_rc} -eq 0 ]]; then
+            break
+        fi
+        if [[ ${attempt} -ge ${rsync_max_attempts} ]]; then
+            printf "rsync failed (exit %d) after %d attempt(s), giving up\n" "${rsync_rc}" "${attempt}" >&2
+            exit "${rsync_rc}"
+        fi
+        printf "rsync failed (exit %d), retrying in %ds (attempt %d/%d)\n" \
+            "${rsync_rc}" "${rsync_retry_delay}" "$((attempt + 1))" "${rsync_max_attempts}" >&2
+        sleep "${rsync_retry_delay}"
+        ((attempt++))
+    done
     printf "\n"
 done
 

--- a/imageroot/bin/take-snapshot
+++ b/imageroot/bin/take-snapshot
@@ -20,8 +20,8 @@ rsync_opts=(-aiSH --no-motd --no-super --no-perms --chmod=ugo=rwX --no-g --no-o 
 distfeed_url=https://github.com/NethServer/ns8-repomd/archive/refs/heads/repomd.tar.gz
 
 # Run "$@", retrying on failure up to retry_max_attempts times with a
-# retry_delay pause in between. Useful to ride out transient network or
-# mirror-side errors without failing the whole snapshot run.
+# retry_delay pause in between. Used for the rsync mirror sync, which has
+# no built-in retry unlike curl (--retry).
 retry() {
     local attempt=1 rc=0
     while true; do
@@ -57,7 +57,9 @@ trap 'rm -rf "${snapshot_dir}"' EXIT
 
 printf "Fetching distfeed from %s\n" "${distfeed_url}"
 mkdir -vp "${snapshot_dir}/distfeed"
-retry curl --fail -L -O --output-dir "${snapshot_dir}" "${distfeed_url}"
+curl --fail -L -O --output-dir "${snapshot_dir}" \
+    --retry "$((retry_max_attempts - 1))" --retry-delay "${retry_delay}" --retry-all-errors \
+    "${distfeed_url}"
 tar -z -x --strip-components=1 -f "${snapshot_dir}/repomd.tar.gz" -C "${snapshot_dir}/distfeed"
 rm -f "${snapshot_dir}/repomd.tar.gz"
 

--- a/imageroot/systemd/user/snapshot.timer
+++ b/imageroot/systemd/user/snapshot.timer
@@ -8,6 +8,7 @@ Description=Timer of Porthos snapshot procedure
 
 [Timer]
 OnCalendar=Fri 21:00:00 UTC
+RandomizedDelaySec=10min
 
 [Install]
 WantedBy=timers.target


### PR DESCRIPTION
## Summary
- Retry the distfeed `curl` fetch and the rsync mirror sync (via a shared `retry()` helper) up to `PORTHOS_RETRY_MAX_ATTEMPTS` times, `PORTHOS_RETRY_DELAY` seconds apart, to ride out transient errors like the `opendir ".~tmp~" failed: Permission denied` seen when the upstream mirror is mid-update.
- Add `RandomizedDelaySec=10min` to `snapshot.timer` so runs aren't all hitting the mirror at the exact same instant.

## Test plan
- [x] `bash -n imageroot/bin/take-snapshot` passes
- [x] Run `take-snapshot` against a real environment and confirm a forced rsync failure triggers a retry and eventually succeeds/gives up as expected

Assisted-by: Claude Code:claude-sonnet-5